### PR TITLE
the globee php client is needed for the plugin to work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "repositories": [
         {
-            "type": "git",
+            "type": "vcs",
             "url": "https://github.com/GloBee-Official/php-bitpay-client.git"
         }
     ],
@@ -23,6 +23,9 @@
             "homepage": "https://bitpay.com/integrations"
         }
     ],
+    "require": {
+        "paybee/php-client": "dev-master"
+    },
     "require-dev": {
         "phpmd/phpmd": "*",
         "phpdocumentor/phpdocumentor": "*",


### PR DESCRIPTION
Without this, the php client doesn't get included in the lib/ directory when the plugin is built, and you'll get "Class not found" errors trying to use it.